### PR TITLE
Improvements and fixes to the CAS

### DIFF
--- a/CudaArchitectureSelector.cmake
+++ b/CudaArchitectureSelector.cmake
@@ -247,7 +247,7 @@ function(cas_get_architectures_by_name name output)
     endif()
     cas_get_supported_architectures(architecture_list)
     list(FILTER architecture_list INCLUDE REGEX "^${${lower_name}_version}[0-9]?")
-    set(${output} ${architecture_list} PARENT_SCOPE)
+    set(${output} "${architecture_list}" PARENT_SCOPE)
 endfunction()
 
 
@@ -274,7 +274,7 @@ endfunction()
 
 
 # Adds or removes entries from a flag list using the ARCHITECTURES or
-# UNUPPORTED lists.
+# UNSUPPORTED lists.
 function(cas_update_flag_list flags_name mode)
     set(flags "${${flags_name}}")
     if(mode STREQUAL "ARCHITECTURES")
@@ -299,7 +299,7 @@ function(cas_update_flag_list flags_name mode)
                 if(arch STREQUAL "")
                     # virtual architecture not specified, use the one corresponding
                     # to the real architecture
-                    set(arch ${code})
+                    set(arch "${code}")
                 endif()
                 if(code STREQUAL "")
                     # real architecture not specified, only generate PTX for the

--- a/CudaArchitectureSelector.cmake
+++ b/CudaArchitectureSelector.cmake
@@ -77,10 +77,10 @@
 # Automatic detection:
 #   Specified by the string ``Auto``. Flags for CUBIN code generation will be
 #   added for all GPU architectures detected on the system. When nothing is
-#   detected, the behavior is the same as `All`.
+#   detected, the behavior is the same as ``All``.
 #
 # All available architectures:
-#   Specified by the string `All``. This option will add flags for CUBIN code
+#   Specified by the string ``All``. This option will add flags for CUBIN code
 #   generation for all GPU architectures supported by the compiler.
 #
 # GPU generation name:
@@ -93,7 +93,7 @@
 # Virtual and physical architecture specification:
 #   A string of the form ``XX(YY)``, where ``XX`` is the identifier of the
 #   physical architecture (e.g. ``XX=32`` represent the physical architecture
-#   ``sm_32``) and ``YY is the identifier of the virtual architecture (e.g. 
+#   ``sm_32``) and ``YY`` is the identifier of the virtual architecture (e.g.
 #   ``YY=52`` represents the virtual architecture ``compute_52``).
 #   Flags necessary to generate CUBIN code for the specified combination of the
 #   physical and virtual architecture will be added to the compiler flags.
@@ -102,7 +102,7 @@
 #   A string of the form ``XX``. Functionally exactly equivalent to ``XX(XX)``.
 #
 # Only virtual architecture specification
-#   A string of the form ``(YY)``, where `YY` is the identifier of the virtual
+#   A string of the form ``(YY)``, where ``YY`` is the identifier of the virtual
 #   architecture. Flags necessary to generate the PTX code (which can be used by
 #   the jitter to compile for the specific device at runtime) for the specified
 #   architecture will be added to the compiler flags.
@@ -113,7 +113,7 @@
 # ``UNSUPPORTED`` architectures list
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# This list has entries of the form `XX`, which represent the architecture
+# This list has entries of the form ``XX``, which represent the architecture
 # (both physical and virtual) identifiers. All code generation for both the
 # physical (CUBIN) and virtual (PTX) architectures matching one of the
 # identifiers in this list will be removed from the list specified by the

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -31,7 +31,7 @@ cas_get_onboard_architectures(onboard)
 message("Architectures present on the system: ${onboard}")
 
 # get list of architectures of a certain generation supported by the compiler
-foreach(gen IN ITEMS Tesla Fermi Kepler Maxwell Pascal Volta)
+foreach(gen IN ITEMS Tesla Fermi Kepler Maxwell Pascal Volta Turing Ampere)
     cas_get_architectures_by_name(${gen} arch_list)
     message("Supported ${gen} generation architectures: ${arch_list}")
 endforeach()


### PR DESCRIPTION
1. Make `Auto` default to `All` when no architecture were detected. This
   behavior prefers adding extra architecture flags rather than ending with
   no flag in the case where compiling is done on a non-GPU enabled
   machine (e.g. login node).
2. Add the Turing architecture and upgrade the architecture regex for
   more complex CUDA architecture versioning.
3. Allow silencing warnings from `cas_get_onboard_architectures` which
   is useful when the place calling this function already prints a warning.
4. Fix a bug where the `if (detected STREQUAL "")` is not used correctly.
5. Fix a major bug when specifying `All`.
6. Update the documentations and examples accordingly.

This also closes #1 (sorry for the very long delay).